### PR TITLE
fix: Fix memory leak in TLibJDO and TLibGrijjyBson

### DIFF
--- a/src/TJ.LibGrijjyBson.pas
+++ b/src/TJ.LibGrijjyBson.pas
@@ -32,7 +32,7 @@ implementation
 
 procedure TLibGrijjyBson.AfterConstruction;
 begin
-  inherited Create;
+  inherited AfterConstruction;
   fName := 'GrijjyBson';
   fJson      := TgoBsonDocument.Create;
   fJsonClone := TgoBsonDocument.Create;

--- a/src/TJ.LibJDO.pas
+++ b/src/TJ.LibJDO.pas
@@ -32,7 +32,7 @@ implementation
 
 procedure TLibJDO.AfterConstruction;
 begin
-  inherited Create;
+  inherited AfterConstruction;
   fName := 'JsonDataObjects';
   fJson      := TJsonObject.Create;
   fJsonClone := TJsonObject.Create;
@@ -87,6 +87,7 @@ var
  jTmp: TJsonBaseObject;
 begin
   Result := False;
+  jTmp := nil;
   try
     jTmp   := fJson.Parse(aCode);
     Result := Assigned(jTmp);


### PR DESCRIPTION
This PR fixes a memory leak in TLibJDO and TLibGrijjyBson.

The overridden `AfterConstruction` method in TLibJDO and TLibGrijjyBson call `inherited Create` instead of `inherited AfterConstruction`. Without calling the `TInterfacedObject.AfterConstruction` method, the `FRefCount` of the object is wrong, causing a `TInterfacedObject` memory leak.

Additionally the `TLibJDO.Check` method doesn't initialize the `jTmp` variable and if `fJson.Parse()` throws an exception, the finally-code runs on the uninitialized variable, causing an access violation.